### PR TITLE
Pc account currency fix and sale_order_type_by_user

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "python.languageServer": "None"
+    "python.languageServer": "None",
+    "github.copilot.nextEditSuggestions.enabled": true
 }

--- a/pc_account_currency/models/account_move.py
+++ b/pc_account_currency/models/account_move.py
@@ -23,5 +23,12 @@ class AccountMove(models.Model):
         self._change_payable_receivable_account()
         res = super().action_post()
         return res
+    
+    def create(self, vals):
+        """ Before create invoice change account for line with account_type in ('asset_receivable', 'liability_payable')"""
+        res = super().create(vals)
+        res._change_payable_receivable_account()
+        return res
+
 
 

--- a/sale_order_type_by_users/__init__.py
+++ b/sale_order_type_by_users/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_order_type_by_users/__manifest__.py
+++ b/sale_order_type_by_users/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "Sale Order Type User Assignment",
+    "summary": "Permite asignar el tipo de pedido de venta por cliente o por usuario",
+    "version": "1.0.0",
+    "category": "Sales",
+    "author": "aiglesas / Primate Uy",
+    "license": "AGPL-3",
+    "depends": ["sale_order_type"],
+    "data": [
+        "views/sale_order_type_view.xml",
+    ],
+    "installable": True,
+    "application": False,
+}

--- a/sale_order_type_by_users/models/__init__.py
+++ b/sale_order_type_by_users/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale_order_type
+from . import sale_order   

--- a/sale_order_type_by_users/models/sale_order.py
+++ b/sale_order_type_by_users/models/sale_order.py
@@ -12,7 +12,6 @@ class SaleOrder(models.Model):
 
             # Buscar si el usuario está asignado a algún tipo de orden de venta
             user_types = self.env["sale.order.type"].search([
-                ("assignment_method", "=", "user"),
                 ("user_ids", "in", record.env.user.id),
                 ("company_id", "in", [record.company_id.id, False]),
             ])
@@ -28,6 +27,9 @@ class SaleOrder(models.Model):
                 )
                 if partner_sale_type:
                     sale_type = partner_sale_type
+                else: 
+                    # Si no hay tipo de orden de venta por cliente, usar el tipo de orden de venta por defecto
+                    sale_type = record.company_id.default_sale_order_type_id
 
-        
+
             record.type_id = sale_type

--- a/sale_order_type_by_users/models/sale_order.py
+++ b/sale_order_type_by_users/models/sale_order.py
@@ -23,7 +23,7 @@ class SaleOrder(models.Model):
                 # Si no, aplicar el flujo por cliente
                 partner_sale_type = (
                     record.partner_id.with_company(record.company_id).sale_type
-                    or record.partner_id.commercial_partner_ived.with_company(record.company_id).sale_type
+                    or record.partner_id.commercial_partner_id.with_company(record.company_id).sale_type
                 )
                 if partner_sale_type:
                     sale_type = partner_sale_type

--- a/sale_order_type_by_users/models/sale_order.py
+++ b/sale_order_type_by_users/models/sale_order.py
@@ -10,26 +10,24 @@ class SaleOrder(models.Model):
         for record in self:
             sale_type = False
 
-            # Si hay tipo por usuario
-            user_sale_type = self.env["sale.order.type"].search([
+            # Buscar si el usuario está asignado a algún tipo de orden de venta
+            user_types = self.env["sale.order.type"].search([
                 ("assignment_method", "=", "user"),
                 ("user_ids", "in", record.env.user.id),
                 ("company_id", "in", [record.company_id.id, False]),
-            ], limit=1)
-
-            if user_sale_type:
+            ])
+            if user_types:
+                # Si el usuario tiene alguno, aplicar el flujo por usuario
+                user_sale_type = user_types[:1]
                 sale_type = user_sale_type
             else:
-                # Si hay tipo por cliente
+                # Si no, aplicar el flujo por cliente
                 partner_sale_type = (
                     record.partner_id.with_company(record.company_id).sale_type
-                    or record.partner_id.commercial_partner_id.with_company(record.company_id).sale_type
+                    or record.partner_id.commercial_partner_ived.with_company(record.company_id).sale_type
                 )
-                if partner_sale_type and partner_sale_type.assignment_method == "partner":
+                if partner_sale_type:
                     sale_type = partner_sale_type
 
-            # Si no hay ninguno, usar el predeterminado
-            if not sale_type:
-                sale_type = record._default_type_id()
-
+        
             record.type_id = sale_type

--- a/sale_order_type_by_users/models/sale_order.py
+++ b/sale_order_type_by_users/models/sale_order.py
@@ -1,0 +1,35 @@
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    @api.depends("partner_id", "company_id")
+    @api.depends_context("partner_id", "company_id", "company")
+    def _compute_sale_type_id(self):
+        for record in self:
+            sale_type = False
+
+            # Si hay tipo por usuario
+            user_sale_type = self.env["sale.order.type"].search([
+                ("assignment_method", "=", "user"),
+                ("user_ids", "in", record.env.user.id),
+                ("company_id", "in", [record.company_id.id, False]),
+            ], limit=1)
+
+            if user_sale_type:
+                sale_type = user_sale_type
+            else:
+                # Si hay tipo por cliente
+                partner_sale_type = (
+                    record.partner_id.with_company(record.company_id).sale_type
+                    or record.partner_id.commercial_partner_id.with_company(record.company_id).sale_type
+                )
+                if partner_sale_type and partner_sale_type.assignment_method == "partner":
+                    sale_type = partner_sale_type
+
+            # Si no hay ninguno, usar el predeterminado
+            if not sale_type:
+                sale_type = record._default_type_id()
+
+            record.type_id = sale_type

--- a/sale_order_type_by_users/models/sale_order.py
+++ b/sale_order_type_by_users/models/sale_order.py
@@ -27,9 +27,7 @@ class SaleOrder(models.Model):
                 )
                 if partner_sale_type:
                     sale_type = partner_sale_type
-                else: 
-                    # Si no hay tipo de orden de venta por cliente, usar el tipo de orden de venta por defecto
-                    sale_type = record.company_id.default_sale_order_type_id
+
 
 
             record.type_id = sale_type

--- a/sale_order_type_by_users/models/sale_order_type.py
+++ b/sale_order_type_by_users/models/sale_order_type.py
@@ -1,0 +1,34 @@
+from odoo import fields, models, api
+from odoo.exceptions import ValidationError
+
+
+class SaleOrderType(models.Model):
+    _inherit = "sale.order.type"
+
+    assignment_method = fields.Selection(
+        selection=[
+            ("partner", "Por cliente"),
+            ("user", "Por usuario"),
+        ],
+        string="Método de asignación",
+        required=True,
+        default="partner",
+    )
+
+    user_ids = fields.Many2many(
+        comodel_name="res.users",
+        string="Usuarios predeterminados",
+    )
+    
+    @api.constrains('user_ids')
+    def _check_unique_user_assignment(self):
+        for record in self:
+            for user in record.user_ids:
+                other_types = self.search([
+                    ('id', '!=', record.id),
+                    ('user_ids', 'in', user.id)
+                ])
+                if other_types:
+                    raise ValidationError(
+                        f"El usuario {user.name} ya está asignado a otro tipo de orden de venta."
+                    )

--- a/sale_order_type_by_users/models/sale_order_type.py
+++ b/sale_order_type_by_users/models/sale_order_type.py
@@ -5,16 +5,6 @@ from odoo.exceptions import ValidationError
 class SaleOrderType(models.Model):
     _inherit = "sale.order.type"
 
-    assignment_method = fields.Selection(
-        selection=[
-            ("partner", "Por cliente"),
-            ("user", "Por usuario"),
-        ],
-        string="Método de asignación",
-        required=True,
-        default="partner",
-    )
-
     user_ids = fields.Many2many(
         comodel_name="res.users",
         string="Usuarios predeterminados",

--- a/sale_order_type_by_users/views/sale_order_type_view.xml
+++ b/sale_order_type_by_users/views/sale_order_type_view.xml
@@ -1,0 +1,14 @@
+
+<odoo>
+    <record id="view_sale_order_type_form_inherit_user_assign" model="ir.ui.view">
+        <field name="name">sale.order.type.form.user.assign</field>
+        <field name="model">sale.order.type</field>
+        <field name="inherit_id" ref="sale_order_type.sot_sale_order_type_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='sequence_id']" position="after">
+                <field name="assignment_method"/>
+                <field name="user_ids" invisible="assignment_method != 'user'" widget="many2many_tags"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/sale_order_type_by_users/views/sale_order_type_view.xml
+++ b/sale_order_type_by_users/views/sale_order_type_view.xml
@@ -6,8 +6,7 @@
         <field name="inherit_id" ref="sale_order_type.sot_sale_order_type_form_view"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='sequence_id']" position="after">
-                <field name="assignment_method"/>
-                <field name="user_ids" invisible="assignment_method != 'user'" widget="many2many_tags"/>
+                <field name="user_ids"  widget="many2many_tags"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
**Pc account currency fix**: agregue este codigo en el modelo account.move:
`        def create(self, vals):
        """ Before create invoice change account for line with account_type in ('asset_receivable', 'liability_payable')"""
        res = super().create(vals)
        res._change_payable_receivable_account()
        return res`
        
       Que lo que hace es que cada vez que se cree una factura se dispare "_change_payable_receivable_account" que es le metodo que Busca la cuenta contable adecuada según la moneda, el diario y el partner en y se las asigna a los apuntos contables, antes solo se ejectuaba cunado habia un cambio en fecha, moneda, diario, partner, líneas de factura o cuando se pasaba la factura de borrador a confirmada, de esta manera podemos ver los apuntes antes de confirmar la factura y sin tener que editar algun campo para que se dispare el onchange.
       
**sale_order_type_by_user**: cree un campo many2many en sale_order_type para asignarle a cada usuario un tipo de venta predeterminado y no depender de los predeterminados de odoo, tambien hago un chequeo para que un usuario solo pertenezca a un tipo.

Luego reescribo el metodo "_compute_sale_type_id" para que busque si el usuario que crea la factura tiene un relacion con un tipo de pedido de venta, si lo tiene va a dejar tipo, sino usa el tipo que tiene el cliente.

En el modulo oringal cada vez que haciamos un cambio en el contacto, se disparaba este metodo e iba a buscar el tipo de pedido de venta del cliente y si no tenia le ponia el tipo "default". De esta manera al cambiar el Cliente se mantiene el tipo de pedido del Usuario